### PR TITLE
:sparkles: Add player network join/quit events

### DIFF
--- a/src/main/java/eu/smashmc/api/core/event/PlayerNetworkJoinEvent.java
+++ b/src/main/java/eu/smashmc/api/core/event/PlayerNetworkJoinEvent.java
@@ -1,0 +1,36 @@
+package eu.smashmc.api.core.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+import com.sun.jdi.event.Event;
+
+import lombok.Getter;
+
+/**
+ * Bukkit {@link Event} that is called when a payer initially joined the network
+ * on this specific server.
+ * 
+ * @author LiquidDev
+ *
+ */
+@Getter
+public class PlayerNetworkJoinEvent extends PlayerEvent {
+
+	private static final HandlerList handlers = new HandlerList();
+
+	public PlayerNetworkJoinEvent(@NotNull Player who) {
+		super(who);
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/main/java/eu/smashmc/api/core/event/PlayerNetworkQuitEvent.java
+++ b/src/main/java/eu/smashmc/api/core/event/PlayerNetworkQuitEvent.java
@@ -10,18 +10,18 @@ import com.sun.jdi.event.Event;
 import lombok.Getter;
 
 /**
- * Bukkit {@link Event} that is called when a player initially joined the
- * network on this specific server.
+ * Bukkit {@link Event} that is called when a player quits the network from this
+ * specific server.
  * 
  * @author LiquidDev
  *
  */
 @Getter
-public class PlayerNetworkJoinEvent extends PlayerEvent {
+public class PlayerNetworkQuitEvent extends PlayerEvent {
 
 	private static final HandlerList handlers = new HandlerList();
 
-	public PlayerNetworkJoinEvent(@NotNull Player who) {
+	public PlayerNetworkQuitEvent(@NotNull Player who) {
 		super(who);
 	}
 


### PR DESCRIPTION
This PR adds PlayerNetworkJoin and PlayerNetworkQuitEvent that are called on the bukkit side of things when a player initially connected to the network or is quitting the network. This was previously very tricky to detect and required the tracking of all players state on every server.
Both events are **only** called on one bukkit server, the one the player is connecting to first or disconnecting from.